### PR TITLE
Small change to properly format the UUID

### DIFF
--- a/library/src/uk/co/alt236/bluetoothlelib/device/mfdata/IBeaconManufacturerData.java
+++ b/library/src/uk/co/alt236/bluetoothlelib/device/mfdata/IBeaconManufacturerData.java
@@ -135,7 +135,7 @@ public final class IBeaconManufacturerData {
 			if(i == 10){sb.append('-');}
 
 			sb.append(
-					Integer.toHexString(ByteUtils.getIntFromByte(uuid[i])));
+					String.format("%02x", ByteUtils.getIntFromByte(uuid[i])));
 		}
 
 


### PR DESCRIPTION
The current implementation removes any leading zeros from a byte thus
the bytes "AB 01 02" will be converted to the string "AB12".
