### PR TITLE
Fixed typographical error, changed advertisment to advertisement in README.

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ Once you have created a device, you can access the following methods:
 **Note:** The Running Average RSSI is not updated automatically (i.e. the library does not monitor on its own in the background). To add another measurement, you need to call `updateRssiReading(long timestamp, int rssiReading)`.
 
 
-### Accessing the Advertisment (Ad) Records
+### Accessing the Advertisement (Ad) Records
 
 Once you've created a BluetoothLe device, you can access the AdRecord store via the `leDevice.getAdRecordStore()`. Once you have the AdRecordStore you can use the following methods:
 


### PR DESCRIPTION
@alt236, I've corrected a typographical error in the documentation of the [Bluetooth-LE-Library---Android](https://github.com/alt236/Bluetooth-LE-Library---Android) project. You should be able to merge this pull request automatically. However, if this was intentional or if you enjoy living in linguistic squalor, please let me know and [create an issue](https://github.com/thoppe/orthographic-pedant/issues/new) on my home repository.